### PR TITLE
Update error message styling and simplify login page title

### DIFF
--- a/royal-care-frontend/src/constants/pageTitles.js
+++ b/royal-care-frontend/src/constants/pageTitles.js
@@ -4,7 +4,7 @@
 const BRAND_SUFFIX = " | Royal Care Pasig";
 
 const pageTitles = {
-  login: "Login" + BRAND_SUFFIX + " Scheduling",
+  login: "Login" + BRAND_SUFFIX,
   register: "Register" + BRAND_SUFFIX,
   registration: "Registration" + BRAND_SUFFIX,
   forgotPassword: "Forgot Password" + BRAND_SUFFIX,

--- a/royal-care-frontend/src/pages/ForgotPasswordPage/ForgotPasswordPage.jsx
+++ b/royal-care-frontend/src/pages/ForgotPasswordPage/ForgotPasswordPage.jsx
@@ -58,7 +58,7 @@ function ForgotPasswordPage() {
     </div>
   );
   const errorMessage = error ? (
-    <div className="global-form-field-error">
+    <div className={styles.errorMessage}>
       {error === "Failed to send reset code. Please try again."
         ? "We couldn't send a reset code to that email. Please check your email address and try again."
         : error}

--- a/royal-care-frontend/src/pages/LoginPage/LoginPage.module.css
+++ b/royal-care-frontend/src/pages/LoginPage/LoginPage.module.css
@@ -97,7 +97,9 @@
   word-break: break-word;
   white-space: pre-line;
   width: 100%;
-  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .statusText {


### PR DESCRIPTION
Simplify the login page title by removing unnecessary text and enhance the styling of error messages on the Forgot Password page for better user experience.